### PR TITLE
feat: GAS 스펠 Ability 베이스 및 기본 스펠 구조 추가

### DIFF
--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/GA_SpellBase.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/GA_SpellBase.cpp
@@ -1,0 +1,208 @@
+#include "GAS/Abilities/GA_SpellBase.h"
+
+#include "HOGDebugHelper.h"
+#include "Data/DA_SpellDefinition.h"
+#include "GameFramework/HOG_GameInstance.h"
+
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "AbilitySystemInterface.h"
+#include "AbilitySystemComponent.h"
+
+UGA_SpellBase::UGA_SpellBase()
+{
+	// 기본적으로 SpellBase 자체는 “설정(Definition 조회/검증)”만 담당한다.
+	// 실제 공격/퍼즐 로직은 파생 Ability에서 구현.
+	// 따라서 별도의 정책 변경은 하지 않고 GA_Base의 기본 정책을 사용한다.
+
+	bWarnIfDefinitionMissing = true;
+}
+
+UDA_SpellDefinition* UGA_SpellBase::GetSpellDefinition() const
+{
+	// 1) SpellID 자체가 유효하지 않으면 조회 불가.
+	//    (태그가 아직 등록/세팅되지 않았거나, 디폴트 값일 수 있음)
+	if (!SpellID.IsValid())
+	{
+		return nullptr;
+	}
+
+	// 2) GAS Ability는 런타임에 CurrentActorInfo가 세팅된다.
+	//    (ASC/Owner/Avatar/World 등 컨텍스트를 담고 있음)
+	if (!CurrentActorInfo)
+	{
+		return nullptr;
+	}
+
+	// 3) World를 얻고 GameInstance를 얻어온다.
+	//    여기서 UHOG_GameInstance는 SpellRegistry를 관리한다.
+	if (!CurrentActorInfo)
+	{
+		return nullptr;
+	}
+
+	UWorld* World = GetWorld();
+	if (!World)
+	{
+		return nullptr;
+	}
+
+	UHOG_GameInstance* GI = Cast<UHOG_GameInstance>(World->GetGameInstance());
+	if (!GI)
+	{
+		return nullptr;
+	}
+
+	// 4) SpellRegistry에서 SpellID로 Definition 조회
+	return GI->GetSpellDefinition(SpellID);
+}
+
+UDA_SpellDefinition* UGA_SpellBase::GetSpellDefinitionOrWarn() const
+{
+	UDA_SpellDefinition* Def = GetSpellDefinition();
+	if (Def)
+	{
+		return Def;
+	}
+
+	// 실패했는데, 경고 출력 옵션이 꺼져 있으면 조용히 nullptr 반환
+	if (!bWarnIfDefinitionMissing)
+	{
+		return nullptr;
+	}
+
+	// 실패 원인은 다양할 수 있다:
+	// - SpellID 미세팅/invalid
+	// - GameInstance 캐스팅 실패(프로젝트 설정에서 다른 GI 사용)
+	// - GI의 SpellDefinitions 배열에 에셋 등록 안함
+	// - BuildSpellRegistry가 호출되지 않음
+	const FString Msg = FString::Printf(
+		TEXT("[GA_SpellBase] SpellDefinition missing. Ability=%s SpellID=%s"),
+		*GetNameSafe(this),
+		*SpellID.ToString()
+	);
+
+	Debug::Print(Msg, FColor::Yellow);
+	return nullptr;
+}
+
+float UGA_SpellBase::GetCooldownSeconds() const
+{
+	// Definition을 조회하고 값 반환. 없으면 0.
+	if (UDA_SpellDefinition* Def = GetSpellDefinitionOrWarn())
+	{
+		return Def->CooldownSeconds;
+	}
+	return 0.f;
+}
+
+float UGA_SpellBase::GetBaseDamage() const
+{
+	if (UDA_SpellDefinition* Def = GetSpellDefinitionOrWarn())
+	{
+		return Def->BaseDamage;
+	}
+	return 0.f;
+}
+
+float UGA_SpellBase::GetCastRange() const
+{
+	if (UDA_SpellDefinition* Def = GetSpellDefinitionOrWarn())
+	{
+		return Def->CastRange;
+	}
+	return 0.f;
+}
+
+bool UGA_SpellBase::DoesTargetMeetRequirements(AActor* Target) const
+{
+	// 타겟이 없으면 당연히 실패
+	if (!IsValid(Target))
+	{
+		return false;
+	}
+
+	// Definition이 없으면 이 스펠의 조건 자체를 판단할 수 없으므로 실패 처리
+	UDA_SpellDefinition* Def = GetSpellDefinitionOrWarn();
+	if (!Def)
+	{
+		return false;
+	}
+
+	// 1) BlockedTags: 하나라도 걸리면 실패
+	if (IsTargetBlocked(Target, Def->TargetBlockedTags))
+	{
+		return false;
+	}
+
+	// 2) RequiredTags: 모두 만족해야 성공
+	if (!HasAllRequiredTags(Target, Def->TargetRequiredTags))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+bool UGA_SpellBase::IsTargetBlocked(AActor* Target, const FGameplayTagContainer& Blocked) const
+{
+	// 차단 태그가 비어있으면 차단 없음
+	if (Blocked.IsEmpty())
+	{
+		return false;
+	}
+
+	// 1차 구현:
+	// - 타겟이 AbilitySystemInterface를 구현하고 있으면,
+	//   타겟 ASC의 OwnedGameplayTags를 읽어서 Blocked와 비교한다.
+	// - 이는 플레이어/적 같은 “캐릭터 계열”에 적용되는 방식이다.
+	if (Target->GetClass()->ImplementsInterface(UAbilitySystemInterface::StaticClass()))
+	{
+		IAbilitySystemInterface* ASI = Cast<IAbilitySystemInterface>(Target);
+		if (ASI)
+		{
+			if (UAbilitySystemComponent* TargetASC = ASI->GetAbilitySystemComponent())
+			{
+				FGameplayTagContainer Owned;
+				TargetASC->GetOwnedGameplayTags(Owned);
+				return Owned.HasAny(Blocked);
+			}
+		}
+	}
+
+	// 퍼즐 오브젝트(ASC 없음)는 현재 버전에서는 “차단 검사 스킵” 처리.
+	// 다음 확장 후보:
+	// - UHOGTagComponent를 붙여서 GameplayTagContainer를 직접 보유
+	// - 또는 ActorTag(FName) -> GameplayTag로 브릿지 비교
+	return false;
+}
+
+bool UGA_SpellBase::HasAllRequiredTags(AActor* Target, const FGameplayTagContainer& Required) const
+{
+	// 요구 태그가 비어있으면 항상 통과
+	if (Required.IsEmpty())
+	{
+		return true;
+	}
+
+	// 캐릭터/적(ASC 보유) 대상:
+	// - ASC의 OwnedTags가 Required를 전부 포함해야 한다.
+	if (Target->GetClass()->ImplementsInterface(UAbilitySystemInterface::StaticClass()))
+	{
+		IAbilitySystemInterface* ASI = Cast<IAbilitySystemInterface>(Target);
+		if (ASI)
+		{
+			if (UAbilitySystemComponent* TargetASC = ASI->GetAbilitySystemComponent())
+			{
+				FGameplayTagContainer Owned;
+				TargetASC->GetOwnedGameplayTags(Owned);
+				return Owned.HasAll(Required);
+			}
+		}
+	}
+
+	// 퍼즐 오브젝트(ASC 없음):
+	// - 현재는 “요구 태그 만족 불가(false)”로 처리.
+	// - 즉, 퍼즐 오브젝트에 RequiredTags 기반 타겟팅을 적용하려면 다음 단계 확장이 필요.
+	return false;
+}

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Accio/GA_Spell_Accio.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Accio/GA_Spell_Accio.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/Accio/GA_Spell_Accio.h"
+

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/BasicAttack/GA_Spell_BasicAttack.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/BasicAttack/GA_Spell_BasicAttack.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/BasicAttack/GA_Spell_BasicAttack.h"
+

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Incendio/GA_Spell_Incendio.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Incendio/GA_Spell_Incendio.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/Incendio/GA_Spell_Incendio.h"
+

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Leviosa/GA_Spell_Leviosa.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Leviosa/GA_Spell_Leviosa.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/Leviosa/GA_Spell_Leviosa.h"
+

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Protego/GA_Spell_Protego.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Protego/GA_Spell_Protego.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/Protego/GA_Spell_Protego.h"
+

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.h"
+

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/GA_SpellBase.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/GA_SpellBase.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "GAS/Abilities/GA_Base.h"
+#include "GA_SpellBase.generated.h"
+
+class UDA_SpellDefinition;
+
+/**
+ * UGA_SpellBase
+ *
+ * [역할]
+ * - “모든 스펠(마법) Ability”의 공통 베이스 클래스.
+ * - 이 클래스는 스펠의 실제 효과(Accio 당기기, Stupefy 충격 등)를 구현하지 않는다.
+ * - 대신 “스펠 데이터(쿨타임/데미지/사거리/타겟 조건)”를 DataAsset로부터 가져오고,
+ *   공통 검증(타겟 태그 조건 등)을 제공한다.
+ *
+ * [데이터 파이프라인]
+ *   (1) UDA_SpellDefinition (PrimaryDataAsset)
+ *       - SpellID(게임플레이태그)를 키로, 쿨타임/데미지/사거리/타겟 요구태그 등을 보관
+ *   (2) UHOG_GameInstance 의 SpellRegistry
+ *       - TMap<SpellID, Definition> 형태로 런타임 조회 가능
+ *   (3) UGA_SpellBase (이 클래스)
+ *       - SpellID를 가지고 있다가, 실행 시 GameInstance에서 Definition을 조회하여 사용
+ *
+ * [중요 설계 의도]
+ * - 스펠의 “진실의 원천”은 Definition(DataAsset)이다.
+ * - 스펠 Ability는 가능한 한 하드코딩을 줄이고, Definition을 읽어서 동작하도록 한다.
+ * - 이후 “스펠 매핑(SpellID -> Primary/Alt GAClass)”은 별도 Mapping DataAsset에서 관리 예정.
+ *
+ * [상속 구조]
+ *   UGA_Base
+ *     └ UGA_SpellBase (여기)
+ *         └ GA_Accio / GA_Stupefy / GA_Leviosa / GA_Incendio ...
+ */
+UCLASS(Abstract)
+class HOGWARTSLEGACYCLONE_API UGA_SpellBase : public UGA_Base
+{
+	GENERATED_BODY()
+
+public:
+	UGA_SpellBase();
+
+	/**
+	 * SpellID
+	 * - 이 Ability가 담당하는 스펠의 고유 ID.
+	 * - 예: Spell.Accio, Spell.Stupefy ...
+	 *
+	 * 사용 방법:
+	 * - 파생 Ability(예: GA_Accio)에서 이 값을 세팅하고,
+	 * - 런타임에 GameInstance 레지스트리에서 Definition을 조회한다.
+	 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell")
+	FGameplayTag SpellID;
+
+	/**
+	 * bWarnIfDefinitionMissing
+	 * - Definition 조회 실패(레지스트리에 없거나 SpellID invalid 등) 시,
+	 *   경고 메시지를 출력할지 여부.
+	 *
+	 * 개발 중에는 true 권장.
+	 * 릴리즈 빌드에서 로그 노이즈가 크면 false로 바꾸면 됨.
+	 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell|Debug")
+	bool bWarnIfDefinitionMissing = true;
+
+public:
+	/**
+	 * GetSpellDefinition()
+	 * - SpellID를 키로 GameInstance SpellRegistry에서 Definition을 조회한다.
+	 * - 실패 시 nullptr.
+	 *
+	 * 주의:
+	 * - 이 함수는 로그 출력 X
+	 * - 로그까지 원하면 GetSpellDefinitionOrWarn() 사용.
+	 */
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell")
+	UDA_SpellDefinition* GetSpellDefinition() const;
+
+	/**
+	 * GetSpellDefinitionOrWarn()
+	 * - GetSpellDefinition()과 동일하지만,
+	 *   실패 시 Debug::Print로 경고를 출력한다.
+	 *
+	 * 용도:
+	 * - 파생 Ability에서 “반드시 Definition이 있어야 하는” 지점에서 사용.
+	 */
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell")
+	UDA_SpellDefinition* GetSpellDefinitionOrWarn() const;
+
+	/**
+	 * 아래 3개는 “Definition의 특정 필드”를 빠르게 꺼내오기 위한 편의 함수.
+	 * - Definition이 없으면 0을 반환한다.
+	 * - 파생 Ability에서는 직접 Def->CooldownSeconds 이런 식으로 써도 되지만,
+	 *   블루프린트 노출이나 공통 사용성을 위해 제공.
+	 */
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell")
+	float GetCooldownSeconds() const;
+
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell")
+	float GetBaseDamage() const;
+
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell")
+	float GetCastRange() const;
+
+	/**
+	 * DoesTargetMeetRequirements()
+	 * - “이 스펠이 이 Target에 적용 가능한가?”를 공통으로 판정한다.
+	 *
+	 * 판정 기준(Definition 기반):
+	 *  1) TargetBlockedTags: 하나라도 포함하면 실패
+	 *  2) TargetRequiredTags: 모두 포함해야 성공
+	 *
+	 * 현재 버전의 한계:
+	 * - ASC(AbilitySystemComponent)가 있는 Actor만 GameplayTagContainer를 읽어 검사 가능.
+	 * - 퍼즐 오브젝트(ASC 없음)는 다음 단계에서 TagComponent/브릿지로 확장 예정.
+	 */
+	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Targeting")
+	bool DoesTargetMeetRequirements(AActor* Target) const;
+
+protected:
+	/**
+	 * IsTargetBlocked()
+	 * - Target이 BlockedTags 중 “하나라도” 보유하면 true(=차단)
+	 *
+	 * 구현상:
+	 * - Target이 AbilitySystemInterface를 구현하면 ASC 태그로 검사한다.
+	 * - ASC가 없는 경우: 현재 버전에서는 false로 처리(차단 검사 스킵)
+	 */
+	bool IsTargetBlocked(AActor* Target, const FGameplayTagContainer& Blocked) const;
+
+	/**
+	 * HasAllRequiredTags()
+	 * - Target이 RequiredTags를 “전부” 보유하면 true
+	 *
+	 * 구현상:
+	 * - Target이 AbilitySystemInterface를 구현하면 ASC 태그로 검사한다.
+	 * - ASC가 없는 경우: 현재 버전에서는 false(=요구태그 만족 불가)로 처리.
+	 */
+	bool HasAllRequiredTags(AActor* Target, const FGameplayTagContainer& Required) const;
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Accio/GA_Spell_Accio.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Accio/GA_Spell_Accio.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_Accio.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_Accio : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/BasicAttack/GA_Spell_BasicAttack.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/BasicAttack/GA_Spell_BasicAttack.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_BasicAttack.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_BasicAttack : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Incendio/GA_Spell_Incendio.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Incendio/GA_Spell_Incendio.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_Incendio.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_Incendio : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Leviosa/GA_Spell_Leviosa.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Leviosa/GA_Spell_Leviosa.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_Leviosa.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_Leviosa : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Protego/GA_Spell_Protego.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Protego/GA_Spell_Protego.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_Protego.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_Protego : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+#include "GA_Spell_Stupefy.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UGA_Spell_Stupefy : public UGA_SpellBase
+{
+	GENERATED_BODY()
+	
+};


### PR DESCRIPTION
- GA_SpellBase Ability 클래스 추가
- 스펠 Ability 폴더 구조 생성 (GAS/Spell)
- 기본 스펠 Ability 클래스 생성

추가된 Ability
- GA_Spell_BasicAttack
- GA_Spell_Protego
- GA_Spell_Accio
- GA_Spell_Stupefy
- GA_Spell_Leviosa
- GA_Spell_Incendio

스펠 시스템은
DA_SpellDefinition → GameInstance SpellRegistry → GA_SpellBase 파이프라인을 기반으로 동작하도록 설계됨.