### PR TITLE
REF: Stupefy 를 Animnotify 기반 VFX/판정구조로 전환

### DIFF
--- a/Source/HogwartsLegacyClone/Private/Character/Player/PlayerCharacterBase.cpp
+++ b/Source/HogwartsLegacyClone/Private/Character/Player/PlayerCharacterBase.cpp
@@ -18,6 +18,14 @@
 #include "Core/HOG_GameplayTags.h"
 #include "HOGDebugHelper.h"
 
+#include "NiagaraComponent.h"
+#include "NiagaraFunctionLibrary.h"
+#include "NiagaraSystem.h"
+
+#include "Components/SkeletalMeshComponent.h"
+#include "Core/HOG_Struct.h"
+#include "GAS/Abilities/GA_SpellBase.h"
+
 
 APlayerCharacterBase::APlayerCharacterBase()
 {
@@ -387,4 +395,98 @@ void APlayerCharacterBase::SetWandVisible(bool bVisible)
 void APlayerCharacterBase::SetCanQueueNextCombo(bool bInCanQueue)
 {
 	bCanQueueNextCombo = bInCanQueue;
+}
+
+void APlayerCharacterBase::QueueSpellVFX(const FQueuedSpellVFXData& InVFXData)
+{
+	QueuedSpellVFXData = InVFXData;
+	QueuedSpellVFXData.bPending = true;
+}
+
+bool APlayerCharacterBase::ConsumeAndSpawnQueuedSpellVFX()
+{
+	if (!QueuedSpellVFXData.bPending)
+	{
+		return false;
+	}
+
+	if (!QueuedSpellVFXData.NiagaraSystem)
+	{
+		QueuedSpellVFXData = FQueuedSpellVFXData();
+		return false;
+	}
+
+	USkeletalMeshComponent* MeshComp = GetMesh();
+	if (!MeshComp)
+	{
+		QueuedSpellVFXData = FQueuedSpellVFXData();
+		return false;
+	}
+
+	FVector StartLocation = GetActorLocation();
+	FRotator SpawnRotation = GetActorRotation();
+
+	if (QueuedSpellVFXData.StartSocketName != NAME_None &&
+		MeshComp->DoesSocketExist(QueuedSpellVFXData.StartSocketName))
+	{
+		StartLocation = MeshComp->GetSocketLocation(QueuedSpellVFXData.StartSocketName);
+	}
+
+	SpawnRotation = (QueuedSpellVFXData.TargetLocation - StartLocation).Rotation();
+
+	UNiagaraComponent* NiagaraComp = UNiagaraFunctionLibrary::SpawnSystemAtLocation(
+		GetWorld(),
+		QueuedSpellVFXData.NiagaraSystem,
+		StartLocation,
+		SpawnRotation,
+		FVector(1.f),
+		true,   // AutoDestroy
+		true,   // AutoActivate
+		ENCPoolMethod::None,
+		true
+	);
+
+	if (NiagaraComp)
+	{
+		NiagaraComp->SetVectorParameter(
+			QueuedSpellVFXData.BeamStartParameterName,
+			StartLocation
+		);
+
+		NiagaraComp->SetVectorParameter(
+			QueuedSpellVFXData.BeamEndParameterName,
+			QueuedSpellVFXData.TargetLocation
+		);
+
+		const float BeamLength = FVector::Distance(StartLocation, QueuedSpellVFXData.TargetLocation);
+
+		NiagaraComp->SetFloatParameter(
+			QueuedSpellVFXData.BeamLengthParameterName,
+			BeamLength
+		);
+	}
+
+	QueuedSpellVFXData = FQueuedSpellVFXData();
+	return NiagaraComp != nullptr;
+}
+
+void APlayerCharacterBase::QueueCastNotifyAbility(UGA_SpellBase* InAbility)
+{
+	QueuedCastNotifyAbility = InAbility;
+}
+
+void APlayerCharacterBase::ConsumeCastNotifyAbility()
+{
+	if (!QueuedCastNotifyAbility)
+	{
+		return;
+	}
+
+	UGA_SpellBase* Ability = QueuedCastNotifyAbility;
+	QueuedCastNotifyAbility = nullptr;
+
+	if (IsValid(Ability))
+	{
+		Ability->HandleCastNotify();
+	}
 }

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/GA_SpellBase.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/GA_SpellBase.cpp
@@ -17,6 +17,13 @@
 #include "Component/LockOnComponent.h"
 #include "TimerManager.h"
 #include "CollisionQueryParams.h"
+#include "Core/HOG_Struct.h"
+
+#include "NiagaraComponent.h"
+#include "NiagaraFunctionLibrary.h"
+#include "NiagaraSystem.h"
+#include "Components/SkeletalMeshComponent.h"
+#include "GameFramework/Character.h"
 
 UGA_SpellBase::UGA_SpellBase()
 {
@@ -175,51 +182,47 @@ bool UGA_SpellBase::TryConsumeLockedTarget(
 		return false;
 	}
 
-	FLockOnTargetResult LockedResult;
-	const bool bHasLockedTarget = LockOn->TryGetLockedTargetResult(LockedResult);
-
-	if (!bHasLockedTarget || !IsValid(LockedResult.TargetActor))
+	AActor* LockedTarget = LockOn->GetCurrentTarget();
+	if (!IsValid(LockedTarget))
 	{
 		BuildFallbackAimPoint(OutAimPoint, Def->CastRange);
 		return false;
 	}
 
-	if (!DoesTargetMeetRequirements(LockedResult.TargetActor))
+	if (!DoesTargetMeetRequirements(LockedTarget))
 	{
-		OutAimPoint = LockedResult.AimPoint.IsNearlyZero()
-			? LockedResult.TargetActor->GetActorLocation()
-			: LockedResult.AimPoint;
+		BuildFallbackAimPoint(OutAimPoint, Def->CastRange);
 		return false;
 	}
 
-	OutTarget = LockedResult.TargetActor;
-	OutTargetTags = LockedResult.TargetTags;
-	OutAimPoint = LockedResult.AimPoint.IsNearlyZero()
-		? LockedResult.TargetActor->GetActorLocation()
-		: LockedResult.AimPoint;
+	OutTarget = LockedTarget;
+	OutAimPoint = LockedTarget->GetActorLocation();
+
+	if (LockedTarget->GetClass()->ImplementsInterface(UAbilitySystemInterface::StaticClass()))
+	{
+		IAbilitySystemInterface* ASI = Cast<IAbilitySystemInterface>(LockedTarget);
+		if (ASI)
+		{
+			if (UAbilitySystemComponent* TargetASC = ASI->GetAbilitySystemComponent())
+			{
+				TargetASC->GetOwnedGameplayTags(OutTargetTags);
+			}
+		}
+	}
 
 	return true;
 }
 
 bool UGA_SpellBase::BuildFallbackAimPoint(FVector& OutAimPoint, float RangeOverride) const
 {
+	OutAimPoint = FVector::ZeroVector;
+
 	if (!CurrentActorInfo)
 	{
 		return false;
 	}
 
 	AActor* Avatar = CurrentActorInfo->AvatarActor.Get();
-	if (!Avatar)
-	{
-		return false;
-	}
-
-	UWorld* World = Avatar->GetWorld();
-	if (!World)
-	{
-		return false;
-	}
-
 	APawn* Pawn = Cast<APawn>(Avatar);
 	if (!Pawn)
 	{
@@ -232,50 +235,33 @@ bool UGA_SpellBase::BuildFallbackAimPoint(FVector& OutAimPoint, float RangeOverr
 		return false;
 	}
 
-	const float RequestedRange = (RangeOverride > 0.f) ? RangeOverride : GetCastRange();
+	const FVector CameraLoc = PC->PlayerCameraManager->GetCameraLocation();
+	const FVector CameraForward = PC->PlayerCameraManager->GetActorForwardVector();
 
-	// 센터에임 목표점은 "카메라가 실제로 보고 있는 월드 지점"을 구하는 용도이므로
-	// 근거리 스킬 사거리 그대로 쓰면 3인칭 카메라-캐릭터 사이 점이 잡힐 수 있다.
-	// 따라서 최소 트레이스 길이를 충분히 길게 보장한다.
-	const float UseRange = FMath::Max(RequestedRange, 5000.f);
+	float TraceDistance = RangeOverride;
+	if (TraceDistance <= 0.f)
+	{
+		TraceDistance = GetCastRange();
+	}
 
-	const FVector CamLoc = PC->PlayerCameraManager->GetCameraLocation();
-	const FVector CamForward = PC->PlayerCameraManager->GetActorForwardVector().GetSafeNormal();
+	// 근거리 주문이어도 카메라-캐릭터 사이의 짧은 점을 잡지 않도록 최소값 보장
+	TraceDistance = FMath::Max(TraceDistance, 5000.f);
 
-	const FVector TraceStart = CamLoc;
-	const FVector TraceEnd = TraceStart + (CamForward * UseRange);
+	const FVector TraceStart = CameraLoc;
+	const FVector TraceEnd = TraceStart + (CameraForward * TraceDistance);
 
-	FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(HOG_SpellBase_FallbackAimTrace), false);
-	QueryParams.AddIgnoredActor(Avatar);
+	FHitResult Hit;
+	FCollisionQueryParams Params(SCENE_QUERY_STAT(SpellBaseFallbackAim), false, Avatar);
 
-	FHitResult HitResult;
-	const bool bHit = World->LineTraceSingleByChannel(
-		HitResult,
+	const bool bHit = GetWorld()->LineTraceSingleByChannel(
+		Hit,
 		TraceStart,
 		TraceEnd,
 		ECC_Visibility,
-		QueryParams
+		Params
 	);
 
-	if (bHit)
-	{
-		OutAimPoint = HitResult.ImpactPoint;
-	}
-	else
-	{
-		OutAimPoint = TraceEnd;
-	}
-
-	/*
-	Debug::Print(FString::Printf(
-		TEXT("[SpellBase] FallbackAim | CamLoc=%s | TraceEnd=%s | OutAimPoint=%s | Hit=%d"),
-		*CamLoc.ToString(),
-		*TraceEnd.ToString(),
-		*OutAimPoint.ToString(),
-		bHit ? 1 : 0
-	));
-	*/
-
+	OutAimPoint = bHit ? Hit.ImpactPoint : TraceEnd;
 	return true;
 }
 
@@ -298,16 +284,6 @@ void UGA_SpellBase::ActivateAbility(
 )
 {
 	Super::ActivateAbility(Handle, ActorInfo, ActivationInfo, TriggerEventData);
-
-	if (ShouldApplyCastingActiveTag())
-	{
-		if (UAbilitySystemComponent* ASC = GetAbilitySystemComponentFromActorInfo())
-		{
-			ASC->AddLooseGameplayTag(
-				FGameplayTag::RequestGameplayTag(TEXT("State.Casting.Active"))
-			);
-		}
-	}
 }
 
 void UGA_SpellBase::EndAbility(
@@ -327,16 +303,7 @@ void UGA_SpellBase::EndAbility(
 	PreCastFacingElapsed = 0.f;
 	bHasCachedPreCastFacingTargetLocation = false;
 	CachedPreCastFacingTargetLocation = FVector::ZeroVector;
-
-	if (ShouldApplyCastingActiveTag())
-	{
-		if (UAbilitySystemComponent* ASC = GetAbilitySystemComponentFromActorInfo())
-		{
-			ASC->RemoveLooseGameplayTag(
-				FGameplayTag::RequestGameplayTag(TEXT("State.Casting.Active"))
-			);
-		}
-	}
+	CachedFacingAbilityForSafety = nullptr;
 
 	Super::EndAbility(Handle, ActorInfo, ActivationInfo, bReplicateEndAbility, bWasCancelled);
 }
@@ -521,19 +488,21 @@ bool UGA_SpellBase::TryBeginPreCastFacing(
 	const FGameplayAbilitySpecHandle Handle,
 	const FGameplayAbilityActorInfo* ActorInfo,
 	const FGameplayAbilityActivationInfo ActivationInfo,
-	const FGameplayEventData* TriggerEventData)
+	const FGameplayEventData* TriggerEventData
+)
 {
 	if (!bRequireFacingBeforeCast)
 	{
 		return false;
 	}
 
-	if (!ShouldDeferCastUntilFacingFinished())
+	if (bWaitingForPreCastFacing)
 	{
-		return false;
+		return true;
 	}
 
-	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(GetAvatarActorFromActorInfo());
+	AActor* Avatar = GetAvatarActorFromActorInfo();
+	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(Avatar);
 	if (!PlayerCharacter)
 	{
 		return false;
@@ -542,8 +511,6 @@ bool UGA_SpellBase::TryBeginPreCastFacing(
 	FVector TargetLocation = FVector::ZeroVector;
 	if (!TryBuildPreCastFacingTargetLocation(TargetLocation))
 	{
-		bHasCachedPreCastFacingTargetLocation = false;
-		CachedPreCastFacingTargetLocation = FVector::ZeroVector;
 		return false;
 	}
 
@@ -551,12 +518,6 @@ bool UGA_SpellBase::TryBeginPreCastFacing(
 	bHasCachedPreCastFacingTargetLocation = true;
 
 	PlayerCharacter->BeginForcedFacingToLocation(TargetLocation);
-
-	if (PlayerCharacter->IsForcedFacingFinished())
-	{
-		PlayerCharacter->StopForcedFacing();
-		return false;
-	}
 
 	CachedFacingHandle = Handle;
 	CachedFacingActivationInfo = ActivationInfo;
@@ -567,7 +528,6 @@ bool UGA_SpellBase::TryBeginPreCastFacing(
 
 	if (UWorld* World = GetWorld())
 	{
-		World->GetTimerManager().ClearTimer(PreCastFacingTimerHandle);
 		World->GetTimerManager().SetTimer(
 			PreCastFacingTimerHandle,
 			this,
@@ -577,17 +537,22 @@ bool UGA_SpellBase::TryBeginPreCastFacing(
 		);
 	}
 
-	return true;
+	return ShouldDeferCastUntilFacingFinished();
 }
 
 void UGA_SpellBase::TickPreCastFacing()
 {
 	if (!bWaitingForPreCastFacing)
 	{
+		if (UWorld* World = GetWorld())
+		{
+			World->GetTimerManager().ClearTimer(PreCastFacingTimerHandle);
+		}
 		return;
 	}
 
-	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(GetAvatarActorFromActorInfo());
+	AActor* Avatar = GetAvatarActorFromActorInfo();
+	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(Avatar);
 	if (!PlayerCharacter)
 	{
 		if (UWorld* World = GetWorld())
@@ -624,7 +589,8 @@ void UGA_SpellBase::OnPreCastFacingFinished(
 	const FGameplayAbilitySpecHandle Handle,
 	const FGameplayAbilityActorInfo* ActorInfo,
 	const FGameplayAbilityActivationInfo ActivationInfo,
-	const FGameplayEventData* TriggerEventData)
+	const FGameplayEventData* TriggerEventData
+)
 {
 	// 파생 ability 에서 override
 }
@@ -632,4 +598,124 @@ void UGA_SpellBase::OnPreCastFacingFinished(
 bool UGA_SpellBase::ShouldDeferCastUntilFacingFinished() const
 {
 	return true;
+}
+
+void UGA_SpellBase::QueueLineTraceSpellVFX(
+	UNiagaraSystem* InVFX,
+	const FVector& InTargetLocation,
+	FName InStartSocketName,
+	FName InBeamStartParam,
+	FName InBeamEndParam,
+	FName InBeamLengthParam
+)
+{
+	if (!InVFX)
+	{
+		return;
+	}
+
+	AActor* Avatar = GetAvatarActorFromActorInfo();
+	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(Avatar);
+	if (!PlayerCharacter)
+	{
+		return;
+	}
+
+	FQueuedSpellVFXData VFXData;
+	VFXData.bPending = true;
+	VFXData.NiagaraSystem = InVFX;
+	VFXData.TargetLocation = InTargetLocation;
+	VFXData.StartSocketName = InStartSocketName;
+	VFXData.BeamStartParameterName = InBeamStartParam;
+	VFXData.BeamEndParameterName = InBeamEndParam;
+	VFXData.BeamLengthParameterName = InBeamLengthParam;
+
+	PlayerCharacter->QueueSpellVFX(VFXData);
+}
+
+void UGA_SpellBase::ClearQueuedLineTraceSpellVFX()
+{
+	QueuedLineTraceBeamVFX = nullptr;
+	QueuedLineTraceBeamTargetLocation = FVector::ZeroVector;
+	QueuedBeamStartSocketName = NAME_None;
+	QueuedBeamStartParamName = TEXT("BeamStart");
+	QueuedBeamEndParamName = TEXT("BeamEnd");
+	QueuedBeamLengthParamName = TEXT("BeamLength");
+}
+
+bool UGA_SpellBase::SpawnQueuedLineTraceSpellVFX()
+{
+	if (!QueuedLineTraceBeamVFX)
+	{
+		return false;
+	}
+
+	AActor* Avatar = GetAvatarActorFromActorInfo();
+	ACharacter* Character = Cast<ACharacter>(Avatar);
+	if (!Character)
+	{
+		ClearQueuedLineTraceSpellVFX();
+		return false;
+	}
+
+	USkeletalMeshComponent* MeshComp = Character->GetMesh();
+	if (!MeshComp)
+	{
+		ClearQueuedLineTraceSpellVFX();
+		return false;
+	}
+
+	FVector StartLocation = Character->GetActorLocation();
+
+	if (QueuedBeamStartSocketName != NAME_None &&
+		MeshComp->DoesSocketExist(QueuedBeamStartSocketName))
+	{
+		StartLocation = MeshComp->GetSocketLocation(QueuedBeamStartSocketName);
+	}
+
+	const FRotator SpawnRotation =
+		(QueuedLineTraceBeamTargetLocation - StartLocation).Rotation();
+
+	UNiagaraComponent* NiagaraComp = UNiagaraFunctionLibrary::SpawnSystemAtLocation(
+		Character->GetWorld(),
+		QueuedLineTraceBeamVFX,
+		StartLocation,
+		SpawnRotation,
+		FVector(1.f),
+		true,
+		true,
+		ENCPoolMethod::None,
+		true
+	);
+
+	if (NiagaraComp)
+	{
+		NiagaraComp->SetVectorParameter(QueuedBeamStartParamName, StartLocation);
+		NiagaraComp->SetVectorParameter(QueuedBeamEndParamName, QueuedLineTraceBeamTargetLocation);
+		NiagaraComp->SetFloatParameter(
+			QueuedBeamLengthParamName,
+			FVector::Distance(StartLocation, QueuedLineTraceBeamTargetLocation)
+		);
+	}
+
+	ClearQueuedLineTraceSpellVFX();
+	return NiagaraComp != nullptr;
+}
+
+void UGA_SpellBase::RegisterCastNotifyToOwner()
+{
+	AActor* Avatar = GetAvatarActorFromActorInfo();
+	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(Avatar);
+	if (!PlayerCharacter)
+	{
+		return;
+	}
+
+	PlayerCharacter->QueueCastNotifyAbility(this);
+}
+
+void UGA_SpellBase::HandleCastNotify()
+{
+	// 기본 SpellBase는 공용 베이스.
+	// 실제 판정/추가 처리(예: Stupefy 데미지 적용)는 파생 클래스에서 override 한다.
 }

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Accio/GA_Spell_Accio.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Accio/GA_Spell_Accio.cpp
@@ -21,6 +21,8 @@
 #include "TimerManager.h"
 #include "DrawDebugHelpers.h"
 
+#include "Components/AudioComponent.h"
+
 UGA_Spell_Accio::UGA_Spell_Accio()
 {
 	InstancingPolicy = EGameplayAbilityInstancingPolicy::InstancedPerActor;
@@ -72,9 +74,16 @@ void UGA_Spell_Accio::ExecuteAccioCast(
 
 	ACharacter* Character = Cast<ACharacter>(ActorInfo ? ActorInfo->AvatarActor.Get() : nullptr);
 
+	// 목소리 사운드 재생
 	if (CastVoiceSound && Character)
 	{
 		UGameplayStatics::PlaySoundAtLocation(this, CastVoiceSound, Character->GetActorLocation());
+	}
+
+	// 시전 사운드 재생
+	if (CastSound && Character)
+	{
+		UGameplayStatics::PlaySoundAtLocation(this, CastSound, Character->GetActorLocation());
 	}
 
 	if (Character && Character->GetMesh() && CastMontage)
@@ -293,6 +302,12 @@ bool UGA_Spell_Accio::FireAccio()
 		UNiagaraFunctionLibrary::SpawnSystemAtLocation(GetWorld(), AccioVFX, OriginalTarget->GetActorLocation());
 	}
 
+	// 당기는 시점에 오디오 컴포넌트 부착 및 재생 시작 ===
+	if (PullSound && IsValid(TargetToMove))
+	{
+		PullAudioComponent = UGameplayStatics::SpawnSoundAttached(PullSound, TargetToMove->GetRootComponent());
+	}
+
 	// 물체의 성질에 따라 중력 무시 처리 세팅
 	if (ACharacter* TargetCharacter = Cast<ACharacter>(TargetToMove))
 	{
@@ -420,6 +435,13 @@ void UGA_Spell_Accio::EndAbility(
 	bool bWasCancelled)
 {
 	if (UWorld* World = GetWorld()) World->GetTimerManager().ClearTimer(PullTimerHandle);
+
+	// === 추가: 어빌리티 종료 시 당기기 소리 강제 종료 ===
+	if (PullAudioComponent)
+	{
+		PullAudioComponent->Stop();
+		PullAudioComponent = nullptr;
+	}
 
 	if (IsValid(TargetToMove))
 	{

--- a/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.cpp
+++ b/Source/HogwartsLegacyClone/Private/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.cpp
@@ -11,10 +11,10 @@
 #include "HOGDebugHelper.h"
 
 #include "GameFramework/Actor.h"
+#include "GameFramework/Character.h"
 
 #include "Animation/AnimInstance.h"
 #include "Animation/AnimMontage.h"
-#include "GameFramework/Character.h"
 
 UGA_SpellStupefy::UGA_SpellStupefy()
 {
@@ -25,7 +25,7 @@ FSpellCastRequest UGA_SpellStupefy::BuildSpellCastRequest(ESpellCastContext Cast
 {
 	FSpellCastRequest Request = Super::BuildSpellCastRequest(CastContext);
 
-	// 패링 반격 Stupefy만 쿨타임 체크 무시 + 발동 후 쿨타임 시작
+	// 패링 반격은 쿨타임 무시
 	if (CastContext == ESpellCastContext::ParryCounter)
 	{
 		Request.bForceIgnoreCooldownCheck = true;
@@ -45,7 +45,7 @@ bool UGA_SpellStupefy::CheckCooldown(
 	{
 		return true;
 	}
-	
+
 	return Super::CheckCooldown(Handle, ActorInfo, OptionalRelevantTags);
 }
 
@@ -57,7 +57,7 @@ void UGA_SpellStupefy::ActivateAbility(
 )
 {
 	Super::ActivateAbility(Handle, ActorInfo, ActivationInfo, TriggerEventData);
-	
+
 	FGameplayTagContainer RelevantTags;
 	if (!CheckCooldown(Handle, ActorInfo, &RelevantTags))
 	{
@@ -65,6 +65,7 @@ void UGA_SpellStupefy::ActivateAbility(
 		return;
 	}
 
+	// 프리 캐스트 페이싱
 	if (TryBeginPreCastFacing(Handle, ActorInfo, ActivationInfo, TriggerEventData))
 	{
 		return;
@@ -104,7 +105,6 @@ void UGA_SpellStupefy::ExecuteStupefyCast(
 		CanCastAsSpecialFreeCast(CheckResult);
 		break;
 
-	case ESpellCastContext::Normal:
 	default:
 		CanCastAsNormal(CheckResult);
 		break;
@@ -135,25 +135,69 @@ void UGA_SpellStupefy::ExecuteStupefyCast(
 		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, false);
 		return;
 	}
-	
+
+	// -------------------------
+	// Notify용 데이터 저장
+	// -------------------------
+	PendingResolvedCastContext = CastContext;
+	PendingResolvedTargetActor = TargetActor;
+	PendingResolvedTargetTags = TargetTags;
+	PendingResolvedAimPoint = AimPoint;
+	bCastNotifyHandled = false;
+
+	// -------------------------
+	// Beam VFX 큐 등록
+	// -------------------------
+	QueueLineTraceSpellVFX(
+		LineTraceBeamVFX,
+		AimPoint,
+		BeamStartSocketName,
+		TEXT("BeamStart"),
+		TEXT("BeamEnd"),
+		TEXT("BeamLength")
+	);
+
+	// Notify가 이 Ability 호출 가능하도록 등록
+	RegisterCastNotifyToOwner();
+
+	// -------------------------
+	// 몽타주 재생
+	// -------------------------
 	ACharacter* Character = Cast<ACharacter>(GetAvatarActorFromActorInfo());
 	if (Character && Character->GetMesh() && CastMontage)
 	{
 		if (UAnimInstance* AnimInstance = Character->GetMesh()->GetAnimInstance())
 		{
-			const float MontageDuration = AnimInstance->Montage_Play(CastMontage, 1.0f);
-			if (MontageDuration > 0.f)
+			const float Duration = AnimInstance->Montage_Play(CastMontage, 1.0f);
+			if (Duration > 0.f)
 			{
 				FOnMontageEnded EndDelegate;
 				EndDelegate.BindUObject(this, &UGA_SpellStupefy::OnMontageEnded);
 				AnimInstance->Montage_SetEndDelegate(EndDelegate, CastMontage);
+				return;
 			}
 		}
 	}
 
-	// 슬로우 모션은 Ability에서 직접 처리하지 않음.
-	// 패링 반격 연출은 애니메이션의 ANS_Stupefy_Slowmotion 에서 처리.
-	const bool bApplied = ApplyStupefyToTarget(CastContext, TargetActor, TargetTags);
+	// fallback (몽타주 없을 때)
+	HandleCastNotify();
+}
+
+void UGA_SpellStupefy::HandleCastNotify()
+{
+	if (bCastNotifyHandled)
+	{
+		return;
+	}
+
+	bCastNotifyHandled = true;
+
+	const bool bApplied = ApplyStupefyToTarget(
+		PendingResolvedCastContext,
+		PendingResolvedTargetActor,
+		PendingResolvedTargetTags
+	);
+
 	if (!bApplied)
 	{
 		ResetPendingCastData();
@@ -161,7 +205,7 @@ void UGA_SpellStupefy::ExecuteStupefyCast(
 		return;
 	}
 
-	NotifySpellCastSucceeded(CastContext);
+	NotifySpellCastSucceeded(PendingResolvedCastContext);
 
 	ResetPendingCastData();
 	EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, false, false);
@@ -178,8 +222,9 @@ void UGA_SpellStupefy::PrepareCastContext(
 
 ESpellCastContext UGA_SpellStupefy::ResolveCastContextAndConsume()
 {
-	const ESpellCastContext ResolvedContext = PendingCastContext;
-	return ResolvedContext;
+	const ESpellCastContext Resolved = PendingCastContext;
+	PendingCastContext = ESpellCastContext::Normal;
+	return Resolved;
 }
 
 bool UGA_SpellStupefy::ResolveTargetForCast(
@@ -193,30 +238,16 @@ bool UGA_SpellStupefy::ResolveTargetForCast(
 	OutTargetTags.Reset();
 	OutAimPoint = FVector::ZeroVector;
 
-	// 패링 반격: 강제 타겟 우선
 	if (InCastContext == ESpellCastContext::ParryCounter)
 	{
 		if (IsValid(PendingForcedTarget) && DoesTargetMeetRequirements(PendingForcedTarget))
 		{
 			OutTarget = PendingForcedTarget;
-			OutAimPoint = PendingForcedTarget->GetActorLocation();
-
-			if (PendingForcedTarget->GetClass()->ImplementsInterface(UAbilitySystemInterface::StaticClass()))
-			{
-				if (IAbilitySystemInterface* ASI = Cast<IAbilitySystemInterface>(PendingForcedTarget))
-				{
-					if (UAbilitySystemComponent* TargetASC = ASI->GetAbilitySystemComponent())
-					{
-						TargetASC->GetOwnedGameplayTags(OutTargetTags);
-					}
-				}
-			}
-
+			OutAimPoint = PendingForcedTarget->GetActorLocation() + FVector(0,0,60);
 			return true;
 		}
 	}
 
-	// 일반 시전 / fallback
 	return TryConsumeLockedTarget(OutTarget, OutTargetTags, OutAimPoint);
 }
 
@@ -231,103 +262,91 @@ bool UGA_SpellStupefy::ApplyStupefyToTarget(
 		return false;
 	}
 
-	AActor* SourceActor = GetAvatarActorFromActorInfo();
-	if (!IsValid(SourceActor))
-	{
-		return false;
-	}
-
 	UCombatComponent* CombatComp = TargetActor->FindComponentByClass<UCombatComponent>();
 	if (!CombatComp)
 	{
 		return false;
 	}
 
-	FDamageRequest DamageRequest;
-	DamageRequest.SourceActor = SourceActor;
-	DamageRequest.TargetActor = TargetActor;
-	DamageRequest.InstigatorActor = SourceActor;
-	DamageRequest.DamageCauser = SourceActor;
-	DamageRequest.BaseDamage = GetBaseDamage();
-	DamageRequest.SourceTags = FGameplayTagContainer();
-	DamageRequest.TargetTags = TargetTags;
+	FDamageRequest Request;
+	Request.SourceActor = GetAvatarActorFromActorInfo();
+	Request.TargetActor = TargetActor;
+	Request.BaseDamage = GetBaseDamage();
+	Request.TargetTags = TargetTags;
 
-	FDamageResult DamageResult = CombatComp->ApplyDamageRequest(DamageRequest);
+	FDamageResult Result = CombatComp->ApplyDamageRequest(Request);
 
-	if (!DamageResult.bWasApplied)
+	if (!Result.bWasApplied)
 	{
 		return false;
 	}
 
-	const bool bStunApplied = ApplyStunEffectToTarget(TargetActor);
+	if (InCastContext == ESpellCastContext::ParryCounter)
+	{
+		ApplyStunEffectToTarget(TargetActor);
+	}
 
-	// 데미지가 이미 적용됐다면 스킬 자체는 성공으로 본다.
 	return true;
 }
 
 bool UGA_SpellStupefy::ApplyStunEffectToTarget(AActor* TargetActor)
 {
-	if (!IsValid(TargetActor))
+	if (!IsValid(TargetActor) || !StunEffectClass)
 	{
 		return false;
 	}
 
-	if (!StunEffectClass)
+	IAbilitySystemInterface* ASI = Cast<IAbilitySystemInterface>(TargetActor);
+	if (!ASI)
 	{
 		return false;
 	}
 
-	if (!TargetActor->GetClass()->ImplementsInterface(UAbilitySystemInterface::StaticClass()))
-	{
-		return false;
-	}
-
-	IAbilitySystemInterface* TargetASI = Cast<IAbilitySystemInterface>(TargetActor);
-	if (!TargetASI)
-	{
-		return false;
-	}
-
-	UAbilitySystemComponent* TargetASC = TargetASI->GetAbilitySystemComponent();
-	if (!TargetASC)
-	{
-		return false;
-	}
-
+	UAbilitySystemComponent* TargetASC = ASI->GetAbilitySystemComponent();
 	UAbilitySystemComponent* SourceASC = GetAbilitySystemComponentFromActorInfo();
-	if (!SourceASC)
+
+	if (!TargetASC || !SourceASC)
 	{
 		return false;
 	}
 
-	FGameplayEffectContextHandle EffectContext = SourceASC->MakeEffectContext();
-	EffectContext.AddSourceObject(this);
+	FGameplayEffectContextHandle Context = SourceASC->MakeEffectContext();
+	FGameplayEffectSpecHandle Spec = SourceASC->MakeOutgoingSpec(StunEffectClass, GetAbilityLevel(), Context);
 
-	FGameplayEffectSpecHandle SpecHandle = SourceASC->MakeOutgoingSpec(StunEffectClass, GetAbilityLevel(), EffectContext);
-	if (!SpecHandle.IsValid())
+	if (!Spec.IsValid())
 	{
 		return false;
 	}
 
-	const FActiveGameplayEffectHandle ActiveGEHandle = SourceASC->ApplyGameplayEffectSpecToTarget(
-		*SpecHandle.Data.Get(),
-		TargetASC
-	);
-
-	const bool bApplied = ActiveGEHandle.WasSuccessfullyApplied();
-
-	return bApplied;
+	return SourceASC->ApplyGameplayEffectSpecToTarget(*Spec.Data.Get(), TargetASC).WasSuccessfullyApplied();
 }
 
 void UGA_SpellStupefy::ResetPendingCastData()
 {
 	PendingCastContext = ESpellCastContext::Normal;
 	PendingForcedTarget = nullptr;
+
+	PendingResolvedCastContext = ESpellCastContext::Normal;
+	PendingResolvedTargetActor = nullptr;
+	PendingResolvedTargetTags.Reset();
+	PendingResolvedAimPoint = FVector::ZeroVector;
+
+	bCastNotifyHandled = false;
 }
 
 void UGA_SpellStupefy::OnMontageEnded(UAnimMontage* Montage, bool bInterrupted)
 {
-	// 현재 방식은 몽타주가 연출용이므로
-	// 종료 시 별도 판정 처리는 하지 않는다.
-	// 필요해지면 이후 Notify 기반으로 전환 가능.
+	if (bCastNotifyHandled)
+	{
+		return;
+	}
+
+	if (bInterrupted)
+	{
+		ResetPendingCastData();
+		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, false);
+		return;
+	}
+
+	HandleCastNotify();
 }

--- a/Source/HogwartsLegacyClone/Private/Notify/AN_SpawnVFX.cpp
+++ b/Source/HogwartsLegacyClone/Private/Notify/AN_SpawnVFX.cpp
@@ -1,0 +1,31 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Notify/AN_SpawnVFX.h"
+
+#include "Character/Player/PlayerCharacterBase.h"
+#include "Components/SkeletalMeshComponent.h"
+
+void UAN_SpawnVFX::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+{
+	Super::Notify(MeshComp, Animation);
+
+	if (!MeshComp)
+	{
+		return;
+	}
+
+	AActor* OwnerActor = MeshComp->GetOwner();
+	APlayerCharacterBase* PlayerCharacter = Cast<APlayerCharacterBase>(OwnerActor);
+	if (!PlayerCharacter)
+	{
+		return;
+	}
+
+	PlayerCharacter->ConsumeAndSpawnQueuedSpellVFX();
+}
+
+FString UAN_SpawnVFX::GetNotifyName_Implementation() const
+{
+	return TEXT("SpawnVFX");
+}

--- a/Source/HogwartsLegacyClone/Public/Character/Player/PlayerCharacterBase.h
+++ b/Source/HogwartsLegacyClone/Public/Character/Player/PlayerCharacterBase.h
@@ -4,6 +4,7 @@
 #include "Character/BaseCharacter.h"
 #include "GameplayTagContainer.h"
 #include "InputActionValue.h"
+#include "Core/HOG_Struct.h"
 #include "PlayerCharacterBase.generated.h"
 
 class USpringArmComponent;
@@ -13,6 +14,8 @@ class UHOGAbilitySystemComponent;
 class UStaticMeshComponent;
 class USkeletalMeshComponent;
 class UAbilitySystemComponent;
+class UNiagaraSystem;
+class UGA_SpellBase;
 
 /**
  * 플레이어 캐릭터 베이스
@@ -193,4 +196,29 @@ public:
 	bool CanQueueNextCombo() const { return bCanQueueNextCombo; }
 
 #pragma endregion
+	
+	
+public:
+	UFUNCTION(BlueprintCallable, Category="Spell|VFX")
+	void QueueSpellVFX(const FQueuedSpellVFXData& InVFXData);
+
+	UFUNCTION(BlueprintCallable, Category="Spell|VFX")
+	bool ConsumeAndSpawnQueuedSpellVFX();
+	
+protected:
+	UPROPERTY(Transient)
+	FQueuedSpellVFXData QueuedSpellVFXData;
+	
+protected:
+	UPROPERTY(Transient)
+	TObjectPtr<UGA_SpellBase> QueuedCastNotifyAbility = nullptr;
+	
+public:
+	UFUNCTION(BlueprintCallable, Category="Spell|VFX")
+	void QueueCastNotifyAbility(UGA_SpellBase* InAbility);
+
+	UFUNCTION(BlueprintCallable, Category="Spell|VFX")
+	void ConsumeCastNotifyAbility();
+	
+	
 };

--- a/Source/HogwartsLegacyClone/Public/Core/HOG_Struct.h
+++ b/Source/HogwartsLegacyClone/Public/Core/HOG_Struct.h
@@ -4,8 +4,9 @@
 #include "GameplayTagContainer.h"
 #include "GameplayEffectTypes.h"
 #include "Core/HOG_Enum.h"
-
 #include "HOG_Struct.generated.h"
+
+class UNiagaraSystem;
 
 USTRUCT(BlueprintType)
 struct HOGWARTSLEGACYCLONE_API FDamageRequest
@@ -162,4 +163,33 @@ public:
 	 */
 	UPROPERTY(BlueprintReadOnly, Category="Spell")
 	FGameplayTag BlockingTag;
+};
+
+
+USTRUCT(BlueprintType)
+struct HOGWARTSLEGACYCLONE_API FQueuedSpellVFXData
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool bPending = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TObjectPtr<UNiagaraSystem> NiagaraSystem = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FVector TargetLocation = FVector::ZeroVector;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FName StartSocketName = NAME_None;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FName BeamStartParameterName = TEXT("BeamStart");
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FName BeamEndParameterName = TEXT("BeamEnd");
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FName BeamLengthParameterName = TEXT("BeamLength");
 };

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/GA_SpellBase.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/GA_SpellBase.h
@@ -11,6 +11,7 @@ class UDA_SpellDefinition;
 class APlayerCharacterBase;
 class ULockOnComponent;
 class USpellComponent;
+class UNiagaraSystem;
 
 /**
  * UGA_SpellBase
@@ -48,18 +49,9 @@ public:
 	UGA_SpellBase();
 
 public:
-	/**
-	 * SpellID
-	 * - 이 Ability가 담당하는 스펠의 고유 ID.
-	 * - 예: Spell.Accio, Spell.Stupefy ...
-	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell")
 	FGameplayTag SpellID;
 
-	/**
-	 * bWarnIfDefinitionMissing
-	 * - Definition 조회 실패 시 경고 메시지 출력 여부
-	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell|Debug")
 	bool bWarnIfDefinitionMissing = true;
 
@@ -106,60 +98,30 @@ protected:
 		bool bWasCancelled) override;
 
 protected:
-	/**
-	 * SpellComponent 접근
-	 * - CurrentActorInfo -> PlayerState -> SpellComponent
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	USpellComponent* GetSpellComponent() const;
 
-	/**
-	 * 기본 시전 요청 생성
-	 * - SpellID
-	 * - CastContext
-	 * - Definition의 CooldownSeconds
-	 * 를 채워서 반환
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	virtual FSpellCastRequest BuildSpellCastRequest(ESpellCastContext CastContext) const;
 
-	/**
-	 * 시전 가능 여부 검사
-	 * - SpellComponent 없으면 실패
-	 * - SpellComponent 있으면 CanCastSpell 호출
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	FSpellCastCheckResult CheckCanCastSpell(ESpellCastContext CastContext) const;
 
-	/**
-	 * 시전 실패 알림
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
-	void NotifySpellCastFailedResult(const FSpellCastRequest& CastRequest,
-	                                 const FSpellCastCheckResult& CheckResult) const;
+	void NotifySpellCastFailedResult(
+		const FSpellCastRequest& CastRequest,
+		const FSpellCastCheckResult& CheckResult
+	) const;
 
-	/**
-	 * 시전 성공 알림
-	 * - 실제 효과 적용이 성공한 뒤 파생 Ability에서 호출
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	void NotifySpellCastSucceeded(ESpellCastContext CastContext) const;
 
-	/**
-	 * 일반 시전 준비 여부 검사
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	bool CanCastAsNormal(FSpellCastCheckResult& OutCheckResult) const;
 
-	/**
-	 * 패링 반격 시전 준비 여부 검사
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	bool CanCastAsParryCounter(FSpellCastCheckResult& OutCheckResult) const;
 
-	/**
-	 * 특수 무료 시전 준비 여부 검사
-	 */
 	UFUNCTION(BlueprintCallable, Category="HOG|Spell|Runtime")
 	bool CanCastAsSpecialFreeCast(FSpellCastCheckResult& OutCheckResult) const;
 
@@ -219,17 +181,6 @@ protected:
 
 	void TickPreCastFacing();
 
-	/**
-	 * 파생 Ability가 Override 해서,
-	 * "회전 완료 후 이어서 실행할 실제 본문"을 구현한다.
-	 *
-	 * 사용법:
-	 * - 파생 ActivateAbility 시작부에서 Super::ActivateAbility(...)
-	 * - 그 다음 if (TryBeginPreCastFacing(...)) return;
-	 * - 아니면 기존 본문 계속 실행
-	 *
-	 * 회전 대기 후에는 이 함수가 자동 호출된다.
-	 */
 	virtual void OnPreCastFacingFinished(
 		const FGameplayAbilitySpecHandle Handle,
 		const FGameplayAbilityActorInfo* ActorInfo,
@@ -237,10 +188,45 @@ protected:
 		const FGameplayEventData* TriggerEventData
 	);
 
-	/**
-	 * 파생 Ability가 "지금은 회전 대기 시작만 하고, 나중에 OnPreCastFacingFinished에서 본문 실행" 구조인지 여부.
-	 * 기본값 true.
-	 */
 	virtual bool ShouldDeferCastUntilFacingFinished() const;
-	
+
+protected:
+	// =========================
+	// LineTrace Beam VFX Queue
+	// =========================
+	UPROPERTY(Transient)
+	TObjectPtr<UNiagaraSystem> QueuedLineTraceBeamVFX = nullptr;
+
+	UPROPERTY(Transient)
+	FVector QueuedLineTraceBeamTargetLocation = FVector::ZeroVector;
+
+	UPROPERTY(Transient)
+	FName QueuedBeamStartSocketName = NAME_None;
+
+	UPROPERTY(Transient)
+	FName QueuedBeamStartParamName = TEXT("BeamStart");
+
+	UPROPERTY(Transient)
+	FName QueuedBeamEndParamName = TEXT("BeamEnd");
+
+	UPROPERTY(Transient)
+	FName QueuedBeamLengthParamName = TEXT("BeamLength");
+
+	void QueueLineTraceSpellVFX(
+	UNiagaraSystem* InVFX,
+	const FVector& InTargetLocation,
+	FName InStartSocketName = TEXT("RightHandWandSocket"),
+	FName InBeamStartParam = TEXT("BeamStart"),
+	FName InBeamEndParam = TEXT("BeamEnd"),
+	FName InBeamLengthParam = TEXT("BeamLength")
+);
+
+	void ClearQueuedLineTraceSpellVFX();
+
+	bool SpawnQueuedLineTraceSpellVFX();
+
+	void RegisterCastNotifyToOwner();
+
+public:
+	virtual void HandleCastNotify();
 };

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Accio/GA_Spell_Accio.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Accio/GA_Spell_Accio.h
@@ -1,6 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
-
-#pragma once
+﻿#pragma once
 
 #include "CoreMinimal.h"
 #include "GAS/Abilities/GA_SpellBase.h"
@@ -9,6 +7,7 @@
 class UAnimMontage;
 class USoundBase;
 class UNiagaraSystem;
+class UAudioComponent;
 
 UCLASS()
 class HOGWARTSLEGACYCLONE_API UGA_Spell_Accio : public UGA_SpellBase
@@ -58,6 +57,18 @@ protected:
 
 	UPROPERTY(EditDefaultsOnly, Category = "HOG|Spell|Accio|Sound")
 	TObjectPtr<USoundBase> CastVoiceSound;
+
+	// 마법 시전 시 나는 마법 이펙트 사운드
+	UPROPERTY(EditDefaultsOnly, Category = "HOG|Spell|Accio|Sound")
+	TObjectPtr<USoundBase> CastSound;
+
+	// 대상을 당기는 동안 나는 루프 사운드
+	UPROPERTY(EditDefaultsOnly, Category = "HOG|Spell|Accio|Sound")
+	TObjectPtr<USoundBase> PullSound;
+
+	// 진행 중인 당기기 사운드를 끄기 위한 컴포넌트
+	UPROPERTY(Transient)
+	TObjectPtr<UAudioComponent> PullAudioComponent;
 
 	UPROPERTY(EditDefaultsOnly, Category = "HOG|Spell|Accio|Visual")
 	TObjectPtr<UNiagaraSystem> AccioVFX;

--- a/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.h
+++ b/Source/HogwartsLegacyClone/Public/GAS/Abilities/Spell/Stupefy/GA_Spell_Stupefy.h
@@ -8,11 +8,17 @@
 class UGameplayEffect;
 class AActor;
 class UAnimMontage;
+class UNiagaraSystem;
 
 /**
  * Stupefy
- * - 일반 시전: LockOn 타겟 대상 즉시 명중, 기절상태 부여 및 데미지 / 쿨타임 진행
- * - 패링 반격: 일반시전 시 진행되는 쿨타임과 무관하게 즉시 시전
+ * - 일반 시전: LockOn 타겟 대상 명중, 데미지 적용
+ * - 패링 반격: 일반 시전 쿨타임과 무관하게 즉시 발동 가능
+ *
+ * 현재 구조:
+ * - Ability 활성화 시 타겟/AimPoint를 먼저 계산
+ * - Commit 이후 빔 VFX 요청을 큐에 넣고 몽타주 재생
+ * - 실제 빔 스폰 / 판정 적용은 AnimNotify(AN_SpawnVFX) 시점에 처리
  *
  * 슬로우 모션은 Ability에서 직접 처리하지 않고,
  * ANS_Stupefy_Slowmotion 에서 처리한다.
@@ -96,8 +102,6 @@ protected:
 	/**
 	 * 패링 반격 연출용 ANS 이름 메모용
 	 * 실제 참조/실행은 애니메이션 쪽에서 처리
-	 * 나중에 애니메이션에 ANS_Stupefy_Slowmotion 만든다음 이걸로 slowmotion 주면 됨
-	 * 
 	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell|Stupefy|Anim")
 	FName ParrySlowMotionANSName = TEXT("ANS_Stupefy_Slowmotion");
@@ -115,12 +119,12 @@ protected:
 	TObjectPtr<AActor> PendingForcedTarget = nullptr;
 
 	/**
- * Stupefy 캐스팅 몽타주
- * - 연출용 재생
- * - 실제 판정은 ExecuteStupefyCast()에서 즉시 처리
- */
+	 * Stupefy 캐스팅 몽타주
+	 * - 연출용 재생
+	 * - 실제 빔/VFX/판정은 Notify 시점에 처리
+	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="HOG|Spell|Stupefy|Anim")
-	TObjectPtr<UAnimMontage> CastMontage;
+	TObjectPtr<UAnimMontage> CastMontage = nullptr;
 
 protected:
 	virtual FSpellCastRequest BuildSpellCastRequest(ESpellCastContext CastContext) const override;
@@ -148,4 +152,35 @@ protected:
 
 	UFUNCTION()
 	void OnMontageEnded(UAnimMontage* Montage, bool bInterrupted);
+
+protected:
+	/** 라인트레이스 주문용 빔 VFX */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="VFX")
+	TObjectPtr<UNiagaraSystem> LineTraceBeamVFX = nullptr;
+
+	/** 빔 시작 소켓 이름 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="VFX")
+	FName BeamStartSocketName = TEXT("RightHandWandSocket");
+
+protected:
+	/**
+	 * Notify 시점까지 실제 적용 데이터를 보관
+	 */
+	UPROPERTY(Transient)
+	TObjectPtr<AActor> PendingResolvedTargetActor = nullptr;
+
+	UPROPERTY(Transient)
+	FGameplayTagContainer PendingResolvedTargetTags;
+
+	UPROPERTY(Transient)
+	FVector PendingResolvedAimPoint = FVector::ZeroVector;
+
+	UPROPERTY(Transient)
+	ESpellCastContext PendingResolvedCastContext = ESpellCastContext::Normal;
+
+	UPROPERTY(Transient)
+	bool bCastNotifyHandled = false;
+
+protected:
+	virtual void HandleCastNotify() override;
 };

--- a/Source/HogwartsLegacyClone/Public/Notify/AN_SpawnVFX.h
+++ b/Source/HogwartsLegacyClone/Public/Notify/AN_SpawnVFX.h
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "AN_SpawnVFX.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class HOGWARTSLEGACYCLONE_API UAN_SpawnVFX : public UAnimNotify
+{
+	GENERATED_BODY()
+	
+public:
+	virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation) override;
+	virtual FString GetNotifyName_Implementation() const override;
+	
+};


### PR DESCRIPTION
- GA_SpellBase에 라인트레이스 VFX 큐 시스템 추가
- Ability → PlayerCharacter → AnimNotify 호출 구조 도입
- UAN_SpawnVFX 공용 AnimNotify 구현

- Stupefy:
  - 즉시 판정 제거
  - Notify 시점에서 Beam + 데미지 + 기절 처리
  - Pending 데이터 구조 추가
  - Montage 종료 fallback 처리

- PlayerCharacterBase:
  - Notify 대상 Ability 큐 관리 기능 추가

결과:
- VFX/판정 타이밍 동기화
- 스킬 연출 자연스러움 개선
- 공통 구조 기반 확장 가능

close #122